### PR TITLE
Serve client UI from default route

### DIFF
--- a/src/Server/ChecklistServer/ChecklistServer.csproj
+++ b/src/Server/ChecklistServer/ChecklistServer.csproj
@@ -14,5 +14,8 @@
   <ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">
     <PackageReference Include="Revit_All_Main_Versions_API_x64" Version="2025.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\Client\index.html" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- embed `index.html` in server
- return the HTML when GET `/` or `/index.html` is requested

## Testing
- `FrameworkPathOverride=/usr/lib/mono/4.8-api dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_687f1c1d06888326b1df14b6c4671288