### PR TITLE
Modern SPA client with dark mode

### DIFF
--- a/src/Client/app.js
+++ b/src/Client/app.js
@@ -1,0 +1,175 @@
+function showError(msg) {
+  document.getElementById('error').textContent = msg;
+}
+
+async function apiFetch(url, options) {
+  try {
+    const resp = await fetch(url, options);
+    if (!resp.ok) {
+      let text = await resp.text();
+      try { const data = JSON.parse(text); text = data.error || text; } catch {}
+      throw new Error(text);
+    }
+    return await resp.json();
+  } catch (err) {
+    showError(err.message);
+    throw err;
+  }
+}
+
+async function fetchUser() {
+  showError('');
+  const data = await apiFetch('/api/user');
+  document.getElementById('user').textContent = 'User: ' + data.user;
+}
+
+function addSection(name = '') {
+  const section = document.createElement('div');
+  section.className = 'section';
+  section.innerHTML = `<input class="section-name" placeholder="Section name" value="${name}">
+      <div class="items"></div>
+      <button class="add-item">Add Item</button>`;
+  section.querySelector('.add-item').onclick = () => addItem(section.querySelector('.items'));
+  document.getElementById('sections').appendChild(section);
+}
+
+function addItem(container, data) {
+  const item = document.createElement('div');
+  item.className = 'item';
+  item.innerHTML = `<input class="item-label" placeholder="Question" value="${data?.label || ''}">
+      <select class="item-type">
+        <option value="checkbox">Checkbox</option>
+        <option value="text">Text</option>
+        <option value="number">Number</option>
+        <option value="dropdown">Dropdown</option>
+      </select>
+      <input class="item-options" placeholder="Comma options" style="display:none">`;
+  const typeSel = item.querySelector('.item-type');
+  const optInput = item.querySelector('.item-options');
+  if (data?.type) typeSel.value = data.type;
+  if (data?.options) { optInput.value = data.options.join(','); optInput.style.display = 'inline'; }
+  typeSel.onchange = () => {
+    if (typeSel.value === 'dropdown') optInput.style.display = 'inline';
+    else { optInput.style.display = 'none'; optInput.value = ''; }
+  };
+  container.appendChild(item);
+}
+
+async function loadTemplates() {
+  showError('');
+  const tpls = await apiFetch('/api/templates');
+  const list = document.getElementById('templatesList');
+  list.innerHTML = '';
+  tpls.forEach(t => {
+    const card = document.createElement('div');
+    card.className = 'card';
+    const title = document.createElement('div');
+    title.textContent = t.name;
+    const btn = document.createElement('button');
+    btn.textContent = 'Create Check';
+    btn.onclick = () => createCheck(t.id);
+    card.appendChild(title);
+    card.appendChild(btn);
+    list.appendChild(card);
+  });
+}
+
+async function loadChecks() {
+  showError('');
+  const checks = await apiFetch('/api/checks');
+  const list = document.getElementById('checksList');
+  list.innerHTML = '';
+  checks.forEach(c => {
+    const card = document.createElement('div');
+    card.className = 'card';
+    card.textContent = c.id + ' (' + c.status + ')';
+    list.appendChild(card);
+  });
+}
+
+async function saveTemplate() {
+  showError('');
+  const name = document.getElementById('tmplName').value.trim();
+  if (!name) return;
+  const sections = [];
+  document.querySelectorAll('#sections .section').forEach(secEl => {
+    const sName = secEl.querySelector('.section-name').value.trim();
+    if (!sName) return;
+    const sec = { id: crypto.randomUUID(), name: sName, items: [] };
+    secEl.querySelectorAll('.items .item').forEach(it => {
+      const label = it.querySelector('.item-label').value.trim();
+      if (!label) return;
+      const type = it.querySelector('.item-type').value;
+      const options = it.querySelector('.item-options').value
+        .split(',').map(o => o.trim()).filter(o => o);
+      const item = { id: crypto.randomUUID(), label, type };
+      if (options.length) item.options = options;
+      sec.items.push(item);
+    });
+    sections.push(sec);
+  });
+  await apiFetch('/api/templates', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, sections })
+  });
+  document.getElementById('tmplName').value = '';
+  document.getElementById('sections').innerHTML = '';
+  loadTemplates();
+}
+
+async function createCheck(tid) {
+  showError('');
+  const templates = await apiFetch('/api/templates');
+  const t = templates.find(x => x.id === tid);
+  if (!t) return;
+  await apiFetch('/api/checks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ templateUniqueId: t.dataStorageUniqueId, templateSnapshot: t, checkedElements: [], answers: [] })
+  });
+  loadChecks();
+}
+
+async function loadLog() {
+  showError('');
+  const data = await apiFetch('/api/log');
+  document.getElementById('logText').textContent = data.log || '';
+}
+
+function applyTheme(theme) {
+  document.documentElement.dataset.theme = theme;
+  document.getElementById('themeToggle').checked = theme === 'dark';
+  localStorage.setItem('theme', theme);
+}
+
+function showPage(page) {
+  document.querySelectorAll('main .page').forEach(p => {
+    p.hidden = p.dataset.page !== page;
+  });
+  document.querySelectorAll('nav a.nav-item').forEach(a => {
+    a.classList.toggle('active', a.getAttribute('href') === '#' + page);
+  });
+  if (page === 'log') loadLog();
+}
+
+function init() {
+  document.getElementById('addSection').onclick = () => addSection();
+  document.getElementById('saveTemplate').onclick = saveTemplate;
+  document.getElementById('refreshLog').onclick = loadLog;
+  document.getElementById('themeToggle').addEventListener('change', e => {
+    applyTheme(e.target.checked ? 'dark' : 'light');
+  });
+  window.addEventListener('hashchange', () => {
+    showPage(location.hash.substring(1) || 'templates');
+  });
+  const savedTheme = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  applyTheme(savedTheme);
+  showPage(location.hash.substring(1) || 'templates');
+  fetchUser();
+  loadTemplates();
+  loadChecks();
+  loadLog();
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/src/Client/index.html
+++ b/src/Client/index.html
@@ -1,182 +1,42 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <title>Revit Quality Checklist</title>
-    <style>
-        body { font-family: Arial, sans-serif; padding: 20px; }
-        h2 { margin-top: 30px; }
-        ul { list-style: none; padding-left: 0; }
-        li { margin-bottom: 5px; }
-        .section { border: 1px solid #ccc; padding: 10px; margin-bottom: 10px; }
-        .item { margin-left: 20px; }
-    </style>
+  <meta charset="UTF-8">
+  <title>Revit Quality Checklist</title>
+  <link rel="stylesheet" href="/style.css">
 </head>
 <body>
+  <header>
     <h1>Revit Quality Checklist</h1>
+    <nav id="nav">
+      <a href="#templates" class="nav-item">Templates</a>
+      <a href="#checks" class="nav-item">Checks</a>
+      <a href="#log" class="nav-item">Log</a>
+      <label class="theme-toggle"><input type="checkbox" id="themeToggle"><span>🌙</span></label>
+    </nav>
     <div id="user"></div>
-    <div id="error" style="color:red"></div>
-
-    <h2>Create Template</h2>
-    <input id="tmplName" placeholder="Template name">
-    <div id="sections"></div>
-    <button id="addSection">Add Section</button>
-    <button id="saveTemplate">Save Template</button>
-
-    <h2>Templates</h2>
-    <ul id="templates"></ul>
-
-    <h2>Checks</h2>
-    <ul id="checks"></ul>
-
-    <h2>Server Log</h2>
-    <pre id="log" style="white-space:pre-wrap;border:1px solid #ccc;padding:10px;height:200px;overflow:auto;"></pre>
-    <button id="refreshLog">Refresh Log</button>
-
-    <script>
-    function showError(msg) {
-        document.getElementById('error').textContent = msg;
-    }
-
-    async function apiFetch(url, options) {
-        try {
-            const resp = await fetch(url, options);
-            if (!resp.ok) {
-                let text = await resp.text();
-                try { const data = JSON.parse(text); text = data.error || text; } catch {}
-                throw new Error(text);
-            }
-            return await resp.json();
-        } catch (err) {
-            showError(err.message);
-            throw err;
-        }
-    }
-
-    async function fetchUser() {
-        showError('');
-        const data = await apiFetch('/api/user');
-        document.getElementById('user').textContent = 'User: ' + data.user;
-    }
-
-    function addSection(name='') {
-        const section = document.createElement('div');
-        section.className = 'section';
-        section.innerHTML = `<input class="section-name" placeholder="Section name" value="${name}">
-            <div class="items"></div>
-            <button class="add-item">Add Item</button>`;
-        section.querySelector('.add-item').onclick = () => addItem(section.querySelector('.items'));
-        document.getElementById('sections').appendChild(section);
-    }
-
-    function addItem(container, data) {
-        const item = document.createElement('div');
-        item.className = 'item';
-        item.innerHTML = `<input class="item-label" placeholder="Question" value="${data?.label || ''}"> 
-            <select class="item-type">
-                <option value="checkbox">Checkbox</option>
-                <option value="text">Text</option>
-                <option value="number">Number</option>
-                <option value="dropdown">Dropdown</option>
-            </select>
-            <input class="item-options" placeholder="Comma options" style="display:none">`;
-        const typeSel = item.querySelector('.item-type');
-        const optInput = item.querySelector('.item-options');
-        if(data?.type) typeSel.value = data.type;
-        if(data?.options) { optInput.value = data.options.join(','); optInput.style.display = 'inline'; }
-        typeSel.onchange = () => {
-            if(typeSel.value === 'dropdown') optInput.style.display = 'inline';
-            else { optInput.style.display = 'none'; optInput.value = ''; }
-        };
-        container.appendChild(item);
-    }
-
-    async function loadTemplates() {
-        showError('');
-        const tpls = await apiFetch('/api/templates');
-        const list = document.getElementById('templates');
-        list.innerHTML = '';
-        tpls.forEach(t => {
-            const li = document.createElement('li');
-            li.textContent = t.name;
-            const btn = document.createElement('button');
-            btn.textContent = 'Create Check';
-            btn.onclick = () => createCheck(t.id);
-            li.appendChild(btn);
-            list.appendChild(li);
-        });
-    }
-
-    async function loadChecks() {
-        showError('');
-        const checks = await apiFetch('/api/checks');
-        const list = document.getElementById('checks');
-        list.innerHTML = '';
-        checks.forEach(c => {
-            const li = document.createElement('li');
-            li.textContent = c.id + ' (' + c.status + ')';
-            list.appendChild(li);
-        });
-    }
-
-    async function saveTemplate() {
-        showError('');
-        const name = document.getElementById('tmplName').value.trim();
-        if (!name) return;
-        const sections = [];
-        document.querySelectorAll('#sections .section').forEach(secEl => {
-            const sName = secEl.querySelector('.section-name').value.trim();
-            if(!sName) return;
-            const sec = { id: crypto.randomUUID(), name: sName, items: [] };
-            secEl.querySelectorAll('.items .item').forEach(it => {
-                const label = it.querySelector('.item-label').value.trim();
-                if(!label) return;
-                const type = it.querySelector('.item-type').value;
-                const options = it.querySelector('.item-options').value
-                    .split(',').map(o=>o.trim()).filter(o=>o);
-                const item = { id: crypto.randomUUID(), label, type };
-                if(options.length) item.options = options;
-                sec.items.push(item);
-            });
-            sections.push(sec);
-        });
-        await apiFetch('/api/templates', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name, sections })
-        });
-        document.getElementById('tmplName').value = '';
-        document.getElementById('sections').innerHTML = '';
-        loadTemplates();
-    }
-
-  async function createCheck(tid) {
-      showError('');
-      const templates = await apiFetch('/api/templates');
-        const t = templates.find(x => x.id === tid);
-        if (!t) return;
-        await apiFetch('/api/checks', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ templateUniqueId: t.dataStorageUniqueId, templateSnapshot: t, checkedElements: [], answers: [] })
-        });
-      loadChecks();
-  }
-
-  async function loadLog() {
-      showError('');
-      const data = await apiFetch('/api/log');
-      document.getElementById('log').textContent = data.log || '';
-  }
-
-  document.getElementById('addSection').addEventListener('click', () => addSection());
-  document.getElementById('saveTemplate').addEventListener('click', saveTemplate);
-  document.getElementById('refreshLog').addEventListener('click', loadLog);
-
-  fetchUser();
-  loadTemplates();
-  loadChecks();
-  loadLog();
-    </script>
+  </header>
+  <div id="error" class="error"></div>
+  <main>
+    <section id="page-templates" class="page" data-page="templates">
+      <h2>Create Template</h2>
+      <input id="tmplName" placeholder="Template name">
+      <div id="sections"></div>
+      <button id="addSection">Add Section</button>
+      <button id="saveTemplate">Save Template</button>
+      <h2>Templates</h2>
+      <div id="templatesList" class="card-list"></div>
+    </section>
+    <section id="page-checks" class="page" data-page="checks" hidden>
+      <h2>Checks</h2>
+      <div id="checksList" class="card-list"></div>
+    </section>
+    <section id="page-log" class="page" data-page="log" hidden>
+      <h2>Server Log</h2>
+      <pre id="logText" class="log"></pre>
+      <button id="refreshLog">Refresh Log</button>
+    </section>
+  </main>
+  <script src="/app.js" defer></script>
 </body>
 </html>

--- a/src/Client/style.css
+++ b/src/Client/style.css
@@ -1,0 +1,87 @@
+:root {
+  --bg: #f4f4f4;
+  --text: #222;
+  --card-bg: #fff;
+  --card-border: #ccc;
+  --nav-bg: #fff;
+  --nav-text: #222;
+}
+[data-theme="dark"] {
+  --bg: #1d1f21;
+  --text: #f4f4f4;
+  --card-bg: #2b2b2b;
+  --card-border: #444;
+  --nav-bg: #222;
+  --nav-text: #f4f4f4;
+}
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 20px;
+  background: var(--nav-bg);
+  color: var(--nav-text);
+  border-bottom: 1px solid var(--card-border);
+}
+nav {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+nav a {
+  color: var(--nav-text);
+  text-decoration: none;
+  padding: 4px 6px;
+  border-radius: 4px;
+}
+nav a.active {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+}
+.theme-toggle {
+  cursor: pointer;
+}
+.page {
+  padding: 20px;
+}
+.card-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 0;
+}
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  padding: 10px;
+  min-width: 200px;
+}
+.section {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+.item {
+  margin-left: 20px;
+}
+.log {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 10px;
+  height: 200px;
+  overflow: auto;
+  white-space: pre-wrap;
+}
+.error {
+  color: red;
+  padding: 0 20px;
+}

--- a/src/Server/ChecklistServer/ChecklistServer.csproj
+++ b/src/Server/ChecklistServer/ChecklistServer.csproj
@@ -16,6 +16,8 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\..\Client\index.html" />
+    <EmbeddedResource Include="..\..\Client\style.css" />
+    <EmbeddedResource Include="..\..\Client\app.js" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- redesign client as SPA with navigation
- add dark/light theme with persistent setting
- present templates, checks and log as cards
- embed new `style.css` and `app.js` in the server
- serve static resources from `HttpListener`

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_687ff4017d2c8326aa8cdd46ebc793ab